### PR TITLE
Move Getting Started to Docs

### DIFF
--- a/Get Started.md
+++ b/Get Started.md
@@ -18,18 +18,49 @@ layout: docpage
 title: Get Started
 ---
 
-# Get started with Royale
+# Getting Started
+All you need to know to start developing with Apache Royale
 
-Royale is an open source project.  You can get the [source code](http://royale.apache.org/source-code/){:target='_blank'} and build Royale, or, if you are in a hurry, you can click [here](Welcome/Get_Started/Download-Royale.html) to find out how to download pre-compiled code and get going quickly.
 
-This section describes:
+## Introduction
+
+Royale is an open source project. You can get the [source code](http://royale.apache.org/source-code/){:target='_blank'} and build Royale, or, if you are in a hurry, you can click here to find out how to download pre-compiled code and get going quickly.
+
+In Apache Royale you develop your applications using ActionScript 3 (AS3) and MXML languages. Your source code is build with the Royale compiler to generate the final Application that will run on the chosen platform.
+
+
+## Getting Royale
 
 [System Requirements](Welcome/Get_Started/System-Requirements.html) - What kinds of computers and operating systems you can use to develop Royale applications.  You can run Royale applications on many more computers, operating systems and even devices such as smartphones and tablets.
 
 [Development Tools](Welcome/Get_Started/Development-tools.html) - You can develop Royale with just the command-line, or you can use scripting/build tools like Apache Ant and Apache Maven, or even use IDEs.
 
-[Frameworks](Welcome/Get_Started/Frameworks.html) - What popular JavaScript frameworks can be used in Royale Applications.
-
 [Download Royale](Welcome/Get_Started/Download-Royale.html) - How to download and set up Royale.
 
+
+## Configuring Royale
+
+Download the binary package of Royale from our Download page and set it up to use with your favorite IDE:
+
++ [Moonshine IDE Configuration](https://github.com/apache/royale-asjs/wiki/Moonshine-IDE){:target='_blank'}
++ [Visual Studio Code Configuration](https://github.com/apache/royale-asjs/wiki/Visual-Studio-Code){:target='_blank'}
++ [Adobe Flash Builder Configuration](https://github.com/apache/royale-asjs/wiki/Flash-Builder-4.7){:target='_blank'}
++ [IntelliJ IDEA Configuration](https://github.com/apache/royale-asjs/wiki/IntelliJ-IDEA){:target='_blank'}
+
+
+## Hello, World!
+
+Follow the instructions for your IDE to create your first “Hello World” application. You can also check out:
+
 [Hello World](Welcome/Get_Started/Hello-World.html) - Build Hello World in Royale.
+
+
+## Where to go from here
+
+[Frameworks](Welcome/Get_Started/Frameworks.html) - What popular JavaScript frameworks can be used in Royale Applications.
+
+In the `royale-asjs` repository repository folder you can find examples in the `examples/royale` directory and framework code in `frameworks/projects` that can help you start to get familiar with Apache Royale.
+
+Tutorials and code examples are coming soon!
+
+Happy Coding!

--- a/_layouts/docpage.html
+++ b/_layouts/docpage.html
@@ -35,7 +35,7 @@ limitations under the License.
 	<a class="topMenu_li_a" href="https://royale.apache.org/features/">FEATURES</a>
 </li>
 <li class="topMenu_li fa">
-	<a class="topMenu_li_a" href="https://royale.apache.org/getting-started/">GET STARTED</a>
+	<a class="topMenu_li_a" href="{{ site.baseurl }}/Get Started.html">GET STARTED</a>
 </li>
 <li class="topMenu_li fa">
 	<a class="topMenu_li_a" href="https://royale.apache.org/download/">DOWNLOAD</a>

--- a/_layouts/docpage.html
+++ b/_layouts/docpage.html
@@ -156,7 +156,7 @@ limitations under the License.
   <div class="footer-column">
   <ul class="footer-list">
     <li class="documentation">DOCUMENTATION</li>
-    <li><a class="footer-list_a" href="https://royale.apache.org/getting-started/">Getting Started</a></li>
+    <li><a class="footer-list_a" href="{{ site.baseurl }}/Get Started.html">Getting Started</a></li>
     <li><a class="footer-list_a" href="https://royale.apache.org/docs/">Docs</a></li>
     <li><a class="footer-list_a" href="https://royale.apache.org/asdoc/">Reference</a></li>
     <li><a class="footer-list_a" href="https://github.com/apache/royale-asjs/wiki">Wiki</a></li>


### PR DESCRIPTION
This feature takes one page of online documentation hosted outside docs:
Getting Started (https://royale.apache.org/getting-started/) 
and merges it with docs:
Get started with Royale (https://apache.github.io/royale-docs/Get%20Started.html)

- The main goal of this feature is to remove duplication. It's confusing to have two pages named 'Getting Started". Where do you start?
- If anyone wants to restructure this page afterward or divide it into parts they are very welcome to do so.
- If this pull request gets accepted it is necessary to make the GET STARTED link on webpage point to the new merged location