### PR TITLE
Make the logo clickable

### DIFF
--- a/_layouts/docpage.html
+++ b/_layouts/docpage.html
@@ -28,8 +28,10 @@ limitations under the License.
 </head>
 
 <body class="page">
-<div class="topbar">
-<img src="https://royale.apache.org/wp-content/uploads/2018/01/apache-royale-tm-logo-light.svg" style="margin-top:15px; margin-bottom: 5px; width: 190px; height: 40px;"/>
+<div class="topbar"> 
+<a href="https://royale.apache.org/">
+  <img src="https://royale.apache.org/wp-content/uploads/2018/01/apache-royale-tm-logo-light.svg" style="margin-top:15px; margin-bottom: 5px; width: 190px; height: 40px;"/>
+</a>
 <ul class="topMenu">
 <li class="topMenu_li fa">
 	<a class="topMenu_li_a" href="https://royale.apache.org/features/">FEATURES</a>


### PR DESCRIPTION
This feature makes the Royale logo in docs clickable. It points to Royale main page.